### PR TITLE
Fix stale port group cache

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = vmware_dvs
-version = 1.0.0
+version = 1.0.1
 summary = Neutron ml2 mechanism driver allowing inclusion of vCenter
     cluster as part of hybrid cloud.
 description-file =

--- a/vmware_dvs/utils/dvs_util.py
+++ b/vmware_dvs/utils/dvs_util.py
@@ -608,7 +608,13 @@ class DVSControllerWithCache(DVSController):
                 self._pg_cache[pg_name]['free_ports_count'] -= 1
                 if port_key not in self._blocked_ports:
                     self._blocked_ports.add(port_key)
-                    p_info = self._get_port_info_by_portkey(port_key)
+                    try:
+                        p_info = self._get_port_info_by_portkey(port_key)
+                    except exceptions.PortNotFound:
+                        # This may be a stale port group cache issue.
+                        # delete the port group and we'll try again.
+                        del(self._pg_cache[pg_name])
+                        raise exceptions.UnboundPortNotFound
                     if not getattr(p_info.config, 'name', None):
                         return p_info
             # free cached ports is ended, but free pg keys exist on vSphere,


### PR DESCRIPTION
The DVS agent can end up in situations where the port groups are
stale. This patch detects when cached ports in the port group are
found to be stale, and purges that cached port group in order to
re-sync with vCenter.

Closes-issue: 461